### PR TITLE
Add logic to evaluate bash commands when parsing config file

### DIFF
--- a/test_proj_configs/build_type.py
+++ b/test_proj_configs/build_type.py
@@ -1,6 +1,6 @@
 import re
 
-from .utils import expect, expand_variables
+from .utils import expect, expand_variables, evaluate_commands
 
 ###############################################################################
 class BuildType(object):
@@ -61,6 +61,9 @@ class BuildType(object):
             'build'   : self
         }
         expand_variables(self,objects)
+
+        # Evaluate remaining bash commands of the form $(...)
+        evaluate_commands(self)
 
         # Properties set at runtime by the TestProjBuild
         self.compile_res_count = None

--- a/test_proj_configs/machine.py
+++ b/test_proj_configs/machine.py
@@ -2,7 +2,7 @@ import pathlib
 import socket
 import re
 
-from .utils import expect, get_available_cpu_count, expand_variables
+from .utils import expect, get_available_cpu_count, expand_variables, evaluate_commands
 
 ###############################################################################
 class Machine(object):
@@ -58,6 +58,9 @@ class Machine(object):
             'machine' : self,
         }
         expand_variables(self,objects)
+
+        # Evaluate remaining bash commands of the form $(...)
+        evaluate_commands(self)
 
         # Check props are valid
         expect (self.mach_file is None or pathlib.Path(self.mach_file).expanduser().exists(),

--- a/test_proj_configs/project.py
+++ b/test_proj_configs/project.py
@@ -1,4 +1,4 @@
-from .utils import expect
+from .utils import expect, evaluate_commands
 
 ###############################################################################
 class Project(object):
@@ -13,7 +13,9 @@ class Project(object):
 
         expect ('name' in project_specs.keys(),
                 "Missing required field 'name' in 'project' section.\n")
+
         self.name = project_specs['name']
+        self.root_dir = root_dir
 
         # If left to None, ALL tests are run during baselines generation
         self.baselines_gen_label = project_specs.get('baseline_gen_label',None)
@@ -27,4 +29,5 @@ class Project(object):
         # If the proj has a cmake var that can turn on/off baselines tests, we can use it
         self.enable_baselines_cmake_option = project_specs.get('enable_baselines_cmake_option',None)
 
-        self.root_dir = root_dir
+        # Evaluate remaining bash commands of the form $(...)
+        evaluate_commands(self)


### PR DESCRIPTION
First we expand variables, then we run bash commands (since variables may be part of the command). It Allows to have stuff like

```yaml
  env_setup: "$(${project.root_dir}/../../cime/CIME/Tools get_case_env)"
```